### PR TITLE
Fix Proc.new deprecation warning in Ruby 2.7

### DIFF
--- a/lib/fixy/record.rb
+++ b/lib/fixy/record.rb
@@ -14,7 +14,7 @@ module Fixy
         @line_ending = character
       end
 
-      def field(name, size, range, type)
+      def field(name, size, range, type, &block)
         @record_fields ||= default_record_fields
         range_matches = range.match /^(\d+)(?:-(\d+))?$/
 
@@ -42,7 +42,7 @@ module Fixy
         # We're good to go :)
         @record_fields[range_from] = { name: name, from: range_from, to: range_to, size: size, type: type}
 
-        field_value(name, Proc.new) if block_given?
+        field_value(name, block) if block_given?
       end
 
       # Convenience method for creating field methods


### PR DESCRIPTION
As of Ruby 2.7 the following code now generates a deprecation warning:

```ruby
lib/fixy/record.rb:45: warning: Capturing the given block using Proc.new is deprecated; use `&block` instead
```
This PR fixes this deprecation